### PR TITLE
複数の型定義をできるように定義できるようにする

### DIFF
--- a/lib/kt_data_class.rb
+++ b/lib/kt_data_class.rb
@@ -1,5 +1,6 @@
 require "kt_data_class/version"
 require "kt_data_class/factory"
+require "kt_data_class/union_syntax"
 
 module KtDataClass
   # @param [Hash] definition

--- a/lib/kt_data_class/base.rb
+++ b/lib/kt_data_class/base.rb
@@ -14,8 +14,14 @@ module KtDataClass
 
       kwargs.each do |attr_name, value|
         klass = self.class.definition[attr_name]
-        unless value.is_a?(klass)
-          raise ArgumentError.new("type mismatch: #{attr_name} must be a #{klass}, #{value.class} given")
+        if klass.is_a?(Array)
+          if klass.none?{|kls| value.is_a?(kls)}
+            raise ArgumentError.new("type mismatch: #{attr_name} must be one of #{klass}, #{value.class} given")
+          end
+        else
+          unless value.is_a?(klass)
+            raise ArgumentError.new("type mismatch: #{attr_name} must be a #{klass}, #{value.class} given")
+          end
         end
         instance_variable_set("@#{attr_name}", value)
       end

--- a/lib/kt_data_class/factory.rb
+++ b/lib/kt_data_class/factory.rb
@@ -7,9 +7,13 @@ module KtDataClass
   class Factory
     def initialize(definition)
       raise_if_invalid(definition)
-      @definition = definition.reject{|attr_name, klass| klass.is_a?(UnionClass)}.merge(
-                    definition.select{|attr_name, klass| klass.is_a?(UnionClass)}.
-                                map{|attr_name, klass| [attr_name, klass.klasses]}.to_h)
+      @definition = definition.map{|attr_name, klass|
+                      if klass.is_a?(UnionClass)
+                        [attr_name, klass.klasses]
+                      else
+                        [attr_name, klass]
+                      end
+                    }.to_h
     end
 
     def create

--- a/lib/kt_data_class/union_syntax.rb
+++ b/lib/kt_data_class/union_syntax.rb
@@ -1,0 +1,34 @@
+module KtDataClass
+  class UnionClass
+    # @param [Array<Class>]
+    def initialize(klasses)
+      if !klasses.is_a?(Array) || klasses.any?{|klass| !klass.is_a?(Class)}
+        raise ArgumentError.new("klasses must be an array of Class")
+      end
+      @klasses = klasses
+    end
+
+    attr_reader :klasses
+
+    def |(other)
+      if other.is_a?(UnionClass)
+        UnionClass.new(@klasses + other.klasses)
+      elsif other.is_a?(Class)
+        UnionClass.new(@klasses + [other])
+      else
+        raise ArgumentError.new("#{other.class} can't be unioned")
+      end
+    end
+  end
+
+  module UnionSyntax
+    refine Class do
+      def |(other_klass)
+        unless other_klass.is_a?(Class)
+          raise ArgumentError.new("#{other_klass.class} can't be unioned")
+        end
+        UnionClass.new([self, other_klass])
+      end
+    end
+  end
+end

--- a/spec/kt_data_class_spec.rb
+++ b/spec/kt_data_class_spec.rb
@@ -44,12 +44,35 @@ RSpec.describe KtDataClass do
   end
 
   describe "データクラスの定義の変更" do
-    let(:definition) { { x: Fixnum} }
+    let(:definition) { { x: Fixnum } }
 
     it '定義の変更の影響を受けないこと' do
       klass = KtDataClass.create(definition)
       definition[:x] = String
       expect{ klass.new(x: 1) }.not_to raise_error(ArgumentError, /type mismatch/)
+    end
+  end
+
+  describe "複数クラスの定義" do
+    context 'Array<Class>指定時' do
+      let(:klass) { KtDataClass.create(x: [Fixnum, NilClass, String]) }
+
+      it '定義されている型が使えること' do
+        expect(klass.new(x: 1).x).to eq(1)
+        expect(klass.new(x: nil).x).to be_nil
+        expect(klass.new(x: "1").x).to eq("1")
+      end
+    end
+
+    context 'UnionSyntax利用時' do
+      using KtDataClass::UnionSyntax
+      let(:klass) { KtDataClass.create(x: Fixnum | NilClass | String) }
+
+      it '定義されている型が使えること' do
+        expect(klass.new(x: 1).x).to eq(1)
+        expect(klass.new(x: nil).x).to be_nil
+        expect(klass.new(x: "1").x).to eq("1")
+      end
     end
   end
 


### PR DESCRIPTION
Fixnum or String とかはよくありそうなので使えるようにしたい。

```
Hoge = KtDataClass.create(x: [Fixnum, String])

Hoge.new(x: 1)
# => #<Point:0x000000000123bb98 @x=1> 

Hoge.new(x: "a")
# => #<Point:0x0000000001231d78 @x="a"> 
```

[rspec-parameterized](https://github.com/tomykaira/rspec-parameterized)のTableSyntaxにならって

```
class Fuga
  using KtDataClass::UnionSyntax

  Point = KtDataClass.create(x: Fixnum|String)

  def calculate
    p1 = Point.new(x: 1)
    p2 = Point.new(x: "a")
    [p1, p2]
  end
end

Fuga.new.calculate
# => [#<Fuga::Point:0x0000000001ddad28 @x=1>, #<Fuga::Point:0x0000000001dda620 @x="a">] 
```

のようにも。