### PR TITLE
文字列変換を実装

### DIFF
--- a/lib/kt_data_class/base.rb
+++ b/lib/kt_data_class/base.rb
@@ -36,6 +36,10 @@ module KtDataClass
     alias_method :to_h, :hash
     alias_method :to_hash, :hash
 
+    def to_s
+      hash.to_s
+    end
+
     def ==(other)
       self.hash == other.hash
     end

--- a/spec/kt_data_class_spec.rb
+++ b/spec/kt_data_class_spec.rb
@@ -85,6 +85,13 @@ RSpec.describe KtDataClass do
     end
   end
 
+  describe 'String変換' do
+    let(:instance) { KtDataClass.create(x: Fixnum, y: NilClass).new(x: 1, y: nil) }
+    it 'ハッシュ文字列に変換されること' do
+      expect(instance.to_s).to eq({x: 1, y: nil}.to_s)
+    end
+  end
+
   describe 'equality' do
     let(:klass1) { KtDataClass.create(x: Fixnum) }
     let(:klass2) { KtDataClass.create(x: Fixnum) }


### PR DESCRIPTION
before

```
Point = KtDataClass.create(x: Fixnum, y: Fixnum)
Point.new(x: 1, y: 2).to_s
 => "#<Point:0x0000000002230ee0>" 
```


after

```
Point = KtDataClass.create(x: Fixnum, y: Fixnum)
Point.new(x: 1, y: 2).to_s
# => "{:x=>1, :y=>2}"
```