### PR TITLE
分割代入できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ p1 = Point.new(x: 3, y: 4)
 p2 = Point.new(x: 3, y: "4")
 # ArgumentError: type mismatch: y must be a Fixnum, String given
 ```
+
+### Destructuring assignment
+
+```
+Point = KtDataClass.create(x: Fixnum, y: Fixnum)
+p = Point.new(x: 1, y: 2)
+x, y = p
+
+x
+# => 1
+
+y
+# => 2
+```

--- a/lib/kt_data_class/base.rb
+++ b/lib/kt_data_class/base.rb
@@ -36,6 +36,14 @@ module KtDataClass
     alias_method :to_h, :hash
     alias_method :to_hash, :hash
 
+    # @see http://maeharin.hatenablog.com/entry/20130107/p1
+    def to_ary
+      self.class.definition.keys.map do |attr_name|
+        instance_variable_get("@#{attr_name}")
+      end
+    end
+    alias_method :to_a, :to_ary
+
     def to_s
       hash.to_s
     end

--- a/spec/kt_data_class_spec.rb
+++ b/spec/kt_data_class_spec.rb
@@ -152,5 +152,15 @@ RSpec.describe KtDataClass do
       it { expect(instance1.eql?(instance2)).to eq(false) }
       it { expect(instance1 === instance2).to eq(false) }
     end
+
+    describe '分割代入' do
+      let(:instance) { KtDataClass.create(a: Fixnum, b: String, c: Float).new(b: "x", c: 1.5, a: 1) }
+      it {
+        a, b, c = instance
+        expect(a).to eq(1)
+        expect(b).to eq("x")
+        expect(c).to eq(1.5)
+      }
+    end
   end
 end


### PR DESCRIPTION
```
Point = KtDataClass.create(x: Fixnum, y: Fixnum)
p = Point.new(x: 1, y: 2)
x, y = p

x
# => 1

y
# => 2
```

副産物として

```
Point = KtDataClass.create(x: Fixnum, y: Fixnum)
p = Point.new(x: 1, y: 2)

p.to_a
# => [1, 2]
```

も。