### PR TITLE
クラス定義時にブロックを渡してメソッドを追加したりできるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ p1 = Point.new(x: 3, y: 4)
 puts p1.x, p1.y
 ```
 
+Also, some convenient methods can be added like below:
+
+```
+Point = KtDataClass.create(x: Fixnum, y: Fixnum) do
+  def -(other)
+    self.class.new(x: x - other.x, y: y - other.y)
+  end
+
+  def norm
+    Math.sqrt(x * x + y * y)
+  end
+end
+
+(Point.new(x: 4, y: 5) - Point.new(x: 1, y: 1)).norm
+# => 5.0
+```
 
 ### Strongly typed
 

--- a/lib/kt_data_class.rb
+++ b/lib/kt_data_class.rb
@@ -4,8 +4,8 @@ require "kt_data_class/union_syntax"
 
 module KtDataClass
   # @param [Hash] definition
-  def create(definition)
-    Factory.new(definition).create
+  def create(definition, &block)
+    Factory.new(definition).create(&block)
   end
 
   module_function :create

--- a/lib/kt_data_class/factory.rb
+++ b/lib/kt_data_class/factory.rb
@@ -16,13 +16,17 @@ module KtDataClass
                     }.to_h
     end
 
-    def create
+    def create(&block)
       member_definition = @definition
       Class.new(Base) do
         define_singleton_method(:definition) do
           member_definition
         end
         attr_reader(*member_definition.keys)
+
+        unless block.nil?
+          class_eval(&block)
+        end
       end
     end
 

--- a/spec/kt_data_class_spec.rb
+++ b/spec/kt_data_class_spec.rb
@@ -76,6 +76,35 @@ RSpec.describe KtDataClass do
     end
   end
 
+  describe 'ブロックの評価' do
+    let(:klass) {
+      KtDataClass.create(x: Fixnum, y: Fixnum) do
+        def norm
+          Math.sqrt(x * x + y * y)
+        end
+
+        def to_s
+          "#<klass {x: #{x}, y: #{y}}>"
+        end
+      end
+    }
+    let(:instance) { klass.new(x: 3, y: 4) }
+    it { expect(instance.norm).to eq(5) }
+    it { expect(instance.to_s).to eq("#<klass {x: 3, y: 4}>") }
+  end
+
+  describe '継承' do
+    let(:instance) {
+      class Point < KtDataClass.create(x: Fixnum, y: Fixnum)
+        def norm
+          Math.sqrt(x * x + y * y)
+        end
+      end
+      Point.new(x: 3, y: 4)
+    }
+    it { expect(instance.norm).to eq(5) }
+  end
+
   describe 'Hash変換' do
     let(:instance) { KtDataClass.create(x: Fixnum, y: NilClass).new(x: 1, y: nil) }
     it '正しくHashに変換されること' do


### PR DESCRIPTION
```
Point = KtDataClass.create(x: Fixnum, y: Fixnum) do
  def norm
    Math.sqrt(x * x + y * y)
  end

  def +(other)
    self.class.new(x: x + other.x, y: y + other.y)
  end
end
p1 = Point.new(x: 3, y: 4)
p2 = Point.new(x: 2, y: 8)

(p1 + p2).norm
# => 13.0
```